### PR TITLE
rename Rect and Vector to PRect and PVector to avoid name conflicts

### DIFF
--- a/libs/pinocchio/attachment.cpp
+++ b/libs/pinocchio/attachment.cpp
@@ -28,7 +28,7 @@ public:
     AttachmentPrivate() {}
     virtual ~AttachmentPrivate() {}
     virtual Mesh deform(const Mesh &mesh, const vector<Transform<> > &transforms) const = 0;
-    virtual Vector<double, -1> getWeights(int i) const = 0;
+    virtual PVector<double, -1> getWeights(int i) const = 0;
     virtual AttachmentPrivate *clone() const = 0;
 };
 
@@ -219,7 +219,7 @@ public:
         return out;
     }
 
-    Vector<double, -1> getWeights(int i) const { return weights[i]; }
+    PVector<double, -1> getWeights(int i) const { return weights[i]; }
 
     AttachmentPrivate *clone() const
     {
@@ -229,7 +229,7 @@ public:
     }
 
 private:
-    vector<Vector<double, -1> > weights;
+    vector<PVector<double, -1> > weights;
     vector<vector<pair<int, double> > > nzweights; //sparse representation
 };
 
@@ -244,7 +244,7 @@ Attachment::Attachment(const Attachment &att)
     a = att.a->clone();
 }
 
-Vector<double, -1> Attachment::getWeights(int i) const { return a->getWeights(i); }
+PVector<double, -1> Attachment::getWeights(int i) const { return a->getWeights(i); }
 
 Mesh Attachment::deform(const Mesh &mesh, const vector<Transform<> > &transforms) const
 {

--- a/libs/pinocchio/attachment.h
+++ b/libs/pinocchio/attachment.h
@@ -72,7 +72,7 @@ public:
     virtual ~Attachment();
 
     Mesh deform(const Mesh &mesh, const vector<Transform<> > &transforms) const;
-    Vector<double, -1> getWeights(int i) const;
+    PVector<double, -1> getWeights(int i) const;
 private:
     AttachmentPrivate *a;
 };

--- a/libs/pinocchio/deriv.h
+++ b/libs/pinocchio/deriv.h
@@ -31,7 +31,7 @@ public:
     Deriv(const Real &inX) : x(inX) {}
     Deriv(const Real &inX, int varNum) : x(inX) { d[varNum] = Real(1.); }
     Deriv(const Self &inD) : x(inD.x), d(inD.d) {}
-    Deriv(const Real &inX, const Vector<Real, Vars> &inD) : x(inX), d(inD) {}
+    Deriv(const Real &inX, const PVector<Real, Vars> &inD) : x(inX), d(inD) {}
     
     Real getReal() const { return x; }
     Real getDeriv(int num = 0) const { return d[num]; }
@@ -57,12 +57,12 @@ public:
     
     //for internal use
     const Real &_x() const { return x; }
-    const Vector<Real, Vars> &_d() const { return d; }
+    const PVector<Real, Vars> &_d() const { return d; }
         
 private:
     
     Real x;
-    Vector<Real, Vars> d;
+    PVector<Real, Vars> d;
 };
 
 #define DerivRV Deriv<Real, Vars>

--- a/libs/pinocchio/discretization.cpp
+++ b/libs/pinocchio/discretization.cpp
@@ -61,7 +61,7 @@ TreeType *constructDistanceField(const Mesh &m, double tol)
 double getMinDot(TreeType *distanceField, const Vector3 &c, double step)
 {
     typedef Deriv<double, 3> D;
-    typedef Vector<D, 3> VD;
+    typedef PVector<D, 3> VD;
     
     int i, j;
     vector<Vector3> vecs;

--- a/libs/pinocchio/dtree.h
+++ b/libs/pinocchio/dtree.h
@@ -27,8 +27,8 @@ class DNode : public Data
 {
 public:
     typedef DNode<Data, Dim> Self;
-    typedef Vector<double, Dim> Vec;
-    typedef Rect<double, Dim> MyRect;
+    typedef PVector<double, Dim> Vec;
+    typedef PRect<double, Dim> MyRect;
 
     int countNodes() const
     {
@@ -102,8 +102,8 @@ public:
     typedef DNode<Data, Dim> Node;
     typedef DRootNode<Data, Dim, Indexer> Self;
     typedef Indexer<Node, Dim> MyIndexer;
-    typedef Vector<double, Dim> Vec;
-    typedef Rect<double, Dim> MyRect;
+    typedef PVector<double, Dim> Vec;
+    typedef PRect<double, Dim> MyRect;
 
     DRootNode(MyRect r = MyRect(Vec(), Vec().apply(bind2nd(plus<double>(), 1.)))) : Node(r)
     {

--- a/libs/pinocchio/multilinear.h
+++ b/libs/pinocchio/multilinear.h
@@ -36,12 +36,12 @@ public:
   const Value &getValue(int idx) const { return values[idx]; }
 
   template<class Real>
-  Real evaluate(const Vector<Real, Dim> &v) const
+  Real evaluate(const PVector<Real, Dim> &v) const
   {
     Real out(0);
     for(int i = 0; i < num; ++i) {
-        Vector<Real, Dim> corner;
-        BitComparator<Dim>::assignCorner(i, v, Vector<Real, Dim>(1.) - v, corner);
+        PVector<Real, Dim> corner;
+        BitComparator<Dim>::assignCorner(i, v, PVector<Real, Dim>(1.) - v, corner);
         Real factor = corner.accumulate(ident<Real>(), multiplies<Real>());
         out += (factor * Real(values[i]));
     }
@@ -49,7 +49,7 @@ public:
   }
 
   template<class Real>
-  Real integrate(const Rect<Real, Dim> &r) const
+  Real integrate(const PRect<Real, Dim> &r) const
   {
     return r.isEmpty() ? Real() : evaluate(r.getCenter()) * r.getContent();
   }

--- a/libs/pinocchio/pointprojector.h
+++ b/libs/pinocchio/pointprojector.h
@@ -52,8 +52,8 @@ template<int Dim, class Obj>
 class ObjectProjector
 {
 public:
-    typedef Vector<double, Dim> Vec;
-    typedef Rect<double, Dim> Rec;
+    typedef PVector<double, Dim> Vec;
+    typedef PRect<double, Dim> Rec;
 
     ObjectProjector() {}
     ObjectProjector(const vector<Obj> &inObjs) : objs(inObjs)

--- a/libs/pinocchio/quaddisttree.h
+++ b/libs/pinocchio/quaddisttree.h
@@ -31,7 +31,7 @@ template<int Dim>
 class DistFunction : public Multilinear<double, Dim>
 {
     typedef Multilinear<double, Dim> super;
-    typedef Rect<double, Dim> MyRect;
+    typedef PRect<double, Dim> MyRect;
 public:
     template<class Eval> void initFunc(const Eval &eval, const MyRect &rect)
     {
@@ -59,7 +59,7 @@ public:
     void fullSplit(const Eval &eval, double tol, DRootNode<DistData<Dim>, Dim, Indexer> *rootNode, int level = 0, bool cropOutside = false)
     {
         int i;
-        const Rect<double, Dim> &rect = node->getRect();
+        const PRect<double, Dim> &rect = node->getRect();
         node->initFunc(eval, rect);
         
         bool nextCropOutside = cropOutside;
@@ -81,9 +81,9 @@ public:
             int idx[Dim + 1];
             for(i = 0; i < Dim + 1; ++i)
                 idx[i] = 0;
-            Vector<double, Dim> center = rect.getCenter();
+            PVector<double, Dim> center = rect.getCenter();
             while(idx[Dim] == 0) {
-                Vector<double, Dim> cur;
+                PVector<double, Dim> cur;
                 bool anyMid = false;
                 for(i = 0; i < Dim; ++i) {
                     switch(idx[i]) {
@@ -110,18 +110,18 @@ public:
             return;
         rootNode->split(node);
         for(i = 0; i < NodeType::numChildren; ++i) {
-            eval.setRect(Rect<double, Dim>(rect.getCorner(i)) | Rect<double, Dim>(rect.getCenter()));
+            eval.setRect(PRect<double, Dim>(rect.getCorner(i)) | PRect<double, Dim>(rect.getCenter()));
             node->getChild(i)->fullSplit(eval, tol, rootNode, level + 1, nextCropOutside);
         }
     }
 
-    template<class Real> Real evaluate(const Vector<Real, Dim> &v)
+    template<class Real> Real evaluate(const PVector<Real, Dim> &v)
     {
         if(node->getChild(0) == NULL) {
             return super::evaluate((v - node->getRect().getLo()).apply(divides<Real>(),
                                                                        node->getRect().getSize()));
         }
-        Vector<Real, Dim> center = node->getRect().getCenter();
+        PVector<Real, Dim> center = node->getRect().getCenter();
         int idx = 0;
         for(int i = 0; i < Dim; ++i)
             if(v[i] > center[i])
@@ -129,14 +129,14 @@ public:
         return node->getChild(idx)->evaluate(v);
     }
 
-    template<class Real> Real integrate(Rect<Real, Dim> r)
+    template<class Real> Real integrate(PRect<Real, Dim> r)
     {
-        r &= Rect<Real, Dim>(node->getRect());
+        r &= PRect<Real, Dim>(node->getRect());
         if(r.isEmpty())
             return Real();
         if(node->getChild(0) == NULL) {
-            Vector<Real, Dim> corner = node->getRect().getLo(), size = node->getRect().getSize();
-            Rect<Real, Dim> adjRect((r.getLo() - corner).apply(divides<Real>(), size),
+            PVector<Real, Dim> corner = node->getRect().getLo(), size = node->getRect().getSize();
+            PRect<Real, Dim> adjRect((r.getLo() - corner).apply(divides<Real>(), size),
                                     (r.getHi() - corner).apply(divides<Real>(), size));
             return Real(node->getRect().getContent()) * super::integrate(adjRect);
         }

--- a/libs/pinocchio/rect.h
+++ b/libs/pinocchio/rect.h
@@ -26,20 +26,20 @@ template <int Dim> class RectOp;
 }
 
 template<class Real, int Dim>
-class Rect {
+class PRect {
 public:
-    typedef Vector<Real, Dim> Vec;
-    typedef Rect<Real, Dim> Self;
+    typedef PVector<Real, Dim> Vec;
+    typedef PRect<Real, Dim> Self;
     typedef _RectPrivate::RectOp<Dim> RO;
     
-    Rect() : empty(true) {}
-    Rect(const Vec &vec) : empty(false), lo(vec), hi(vec) {}
-    Rect(const Vec &inLo, const Vec &inHi) : lo(inLo), hi(inHi) { markEmpty(); }
-    Rect(const Rect &inRect) : empty(inRect.empty), lo(inRect.lo), hi(inRect.hi) {}
-    template<class R> Rect(const Rect<R, Dim> &inRect) : empty(inRect.empty), lo(inRect.lo), hi(inRect.hi) {}
+    PRect() : empty(true) {}
+    PRect(const Vec &vec) : empty(false), lo(vec), hi(vec) {}
+    PRect(const Vec &inLo, const Vec &inHi) : lo(inLo), hi(inHi) { markEmpty(); }
+    PRect(const PRect &inRect) : empty(inRect.empty), lo(inRect.lo), hi(inRect.hi) {}
+    template<class R> PRect(const PRect<R, Dim> &inRect) : empty(inRect.empty), lo(inRect.lo), hi(inRect.hi) {}
     
     //constructs a Rect given an iterator over points--could be optimized with a min-max
-    template<class Iter> Rect(Iter start, const Iter &finish) : empty(false)
+    template<class Iter> PRect(Iter start, const Iter &finish) : empty(false)
     {
         if(start == finish) {
             empty = true;
@@ -113,20 +113,20 @@ public:
     }
     
 private:
-    template<class R, int D> friend class Rect;
+    template<class R, int D> friend class PRect;
 
-    Rect(bool inEmpty, const Vec &inLo, const Vec &inHi) : empty(inEmpty), lo(inLo), hi(inHi) { }
+    PRect(bool inEmpty, const Vec &inLo, const Vec &inHi) : empty(inEmpty), lo(inLo), hi(inHi) { }
     void markEmpty() { empty = hi.accumulate(less<Real>(), logical_or<bool>(), lo); }
 
     bool empty;
     Vec lo, hi;
 };
 
-typedef Rect<double, 2> Rect2;
-typedef Rect<double, 3> Rect3;
+typedef PRect<double, 2> Rect2;
+typedef PRect<double, 3> Rect3;
 
 template <class charT, class traits, class Real, int Dim>
-        basic_ostream<charT,traits>& operator<<(basic_ostream<charT,traits>& os, const Rect<Real, Dim> &r)
+        basic_ostream<charT,traits>& operator<<(basic_ostream<charT,traits>& os, const PRect<Real, Dim> &r)
 {
     if(r.isEmpty())
         os << "Rect()";
@@ -136,12 +136,12 @@ template <class charT, class traits, class Real, int Dim>
 }
 
 namespace _RectPrivate {
-#define VRD Vector<R, D>
-#define RRD Rect<R, D>
+#define VRD PVector<R, D>
+#define RRD PRect<R, D>
 template <int Dim>
 class RectOp
 {
-private:
+public:
     static const int last = Dim - 1;
     typedef RectOp<Dim - 1> Next;
     template<int D> friend class RectOp;

--- a/libs/pinocchio/refinement.cpp
+++ b/libs/pinocchio/refinement.cpp
@@ -38,7 +38,7 @@ struct RP //information for refined embedding
     ObjectProjector<3, Vec3Object> medProjector;
 };
 
-template<class Real> Real computeFineError(const vector<Vector<Real, 3> > &match, RP *rp)
+template<class Real> Real computeFineError(const vector<PVector<Real, 3> > &match, RP *rp)
 {
     Real out = Real();
     int i;
@@ -54,9 +54,9 @@ template<class Real> Real computeFineError(const vector<Vector<Real, 3> > &match
         const int samples = 10;
         for(int k = 0; k < samples; ++k) {
             double frac = double(k) / double(samples);
-            Vector<Real, 3> cur = match[i] * Real(1. - frac) + match[prev] * Real(frac);
+            PVector<Real, 3> cur = match[i] * Real(1. - frac) + match[prev] * Real(frac);
             Vector3 m = rp->medProjector.project(cur);
-            Real medDist = (cur - Vector<Real, 3>(m)).length();
+            Real medDist = (cur - PVector<Real, 3>(m)).length();
             Real surfDist = -rp->distanceField->locate(cur)->evaluate(cur);
             Real penalty = SQR(min(medDist, Real(0.001) + max(Real(0.), Real(0.05) - surfDist)));
             if(penalty > Real(SQR(0.003)))
@@ -80,8 +80,8 @@ template<class Real> Real computeFineError(const vector<Vector<Real, 3> > &match
         
         //--------------angle
         if(distSq > Real(1e-16)) {
-            Vector<Real, 3> curDir = (match[i] - match[prev]).normalize();
-            Vector<Real, 3> skelDir = (rp->given.fGraph().verts[i] - rp->given.fGraph().verts[prev]).normalize();
+            PVector<Real, 3> curDir = (match[i] - match[prev]).normalize();
+            PVector<Real, 3> skelDir = (rp->given.fGraph().verts[i] - rp->given.fGraph().verts[prev]).normalize();
             if(curDir * skelDir < Real(1. - 1e-8))
                 anglePenalty = Real(0.5) * acos(curDir * skelDir);
             anglePenalty = CUBE(Real(0.3) + anglePenalty);
@@ -148,7 +148,7 @@ vector<Vector3> refineEmbedding(TreeType *distanceField, const vector<Vector3> &
         Debugging::out() << "E = " << computeFineError(fineEmbedding, &rp) << endl;
         
         for(int j = 0; j < 2; ++j) {
-            vector<Vector<DType1, 3> > dMatch(sz);
+            vector<PVector<DType1, 3> > dMatch(sz);
             for(i = 0; i < sz; ++i) {
                 dMatch[i][0] = DType1(fineEmbedding[i][0], i * 3);
                 dMatch[i][1] = DType1(fineEmbedding[i][1], i * 3 + 1);
@@ -170,7 +170,7 @@ vector<Vector3> refineEmbedding(TreeType *distanceField, const vector<Vector3> &
         for(cur = 1; cur < sz; ++cur) {
             int prev = skeleton.fPrev()[cur];
             
-            vector<Vector<DType, 3> > dMatch(sz);
+            vector<PVector<DType, 3> > dMatch(sz);
             for(i = 0; i < sz; ++i) {
                 dMatch[i][0] = DType(fineEmbedding[i][0]);
                 dMatch[i][1] = DType(fineEmbedding[i][1]);

--- a/libs/pinocchio/transform.h
+++ b/libs/pinocchio/transform.h
@@ -30,15 +30,15 @@ public:
     Quaternion(const Quaternion &q) : r(q.r), v(q.v) {} //copy constructor
     template<class R> Quaternion(const Quaternion<R> &q) : r(q.r), v(q.v) {} //convert quaternions of other types
     //axis angle constructor:
-    template<class R> Quaternion(const Vector<R, 3> &axis, const R &angle) : r(cos(angle * Real(0.5))), v(sin(angle * Real(0.5)) * axis.normalize()) {}
+    template<class R> Quaternion(const PVector<R, 3> &axis, const R &angle) : r(cos(angle * Real(0.5))), v(sin(angle * Real(0.5)) * axis.normalize()) {}
     //minimum rotation constructor:
-    template<class R> Quaternion(const Vector<R, 3> &from, const Vector<R, 3> &to) : r(1.)
+    template<class R> Quaternion(const PVector<R, 3> &from, const PVector<R, 3> &to) : r(1.)
     {
         R fromLenSq = from.lengthsq(), toLenSq = to.lengthsq();
         if(fromLenSq < toLenSq) {
             if(fromLenSq < R(1e-16))
                 return;
-            Vector<R, 3> mid = from * sqrt(toLenSq / fromLenSq) + to;
+            PVector<R, 3> mid = from * sqrt(toLenSq / fromLenSq) + to;
             R fac = 1. / sqrt(mid.lengthsq() * toLenSq);
             r = (mid * to) * fac;
             v = (mid % to) * fac;
@@ -46,7 +46,7 @@ public:
         else {
             if(toLenSq < R(1e-16))
                 return;
-            Vector<R, 3> mid = from + to * sqrt(fromLenSq / toLenSq);
+            PVector<R, 3> mid = from + to * sqrt(fromLenSq / toLenSq);
             R fac = 1. / sqrt(mid.lengthsq() * fromLenSq);
             r = (from * mid) * fac;
             v = (from % mid) * fac;
@@ -57,13 +57,13 @@ public:
     Quaternion operator*(const Quaternion &q) const { return Quaternion(r * q.r - v * q.v, r * q.v + q.r * v + v % q.v); }
     
     //transforming a vector
-    Vector<Real, 3> operator*(const Vector<Real, 3> &p) const
+    PVector<Real, 3> operator*(const PVector<Real, 3> &p) const
     {
-        Vector<Real, 3> v2 = v + v;
-        Vector<Real, 3> vsq2 = v.apply(multiplies<Real>(), v2);
-        Vector<Real, 3> rv2 = r * v2;
-        Vector<Real, 3> vv2(v[1] * v2[2], v[0] * v2[2], v[0] * v2[1]);
-        return Vector<Real, 3>(p[0] * (Real(1.) - vsq2[1] - vsq2[2]) + p[1] * (vv2[2] - rv2[2]) + p[2] * (vv2[1] + rv2[1]),
+        PVector<Real, 3> v2 = v + v;
+        PVector<Real, 3> vsq2 = v.apply(multiplies<Real>(), v2);
+        PVector<Real, 3> rv2 = r * v2;
+        PVector<Real, 3> vv2(v[1] * v2[2], v[0] * v2[2], v[0] * v2[1]);
+        return PVector<Real, 3>(p[0] * (Real(1.) - vsq2[1] - vsq2[2]) + p[1] * (vv2[2] - rv2[2]) + p[2] * (vv2[1] + rv2[1]),
                                p[1] * (Real(1.) - vsq2[2] - vsq2[0]) + p[2] * (vv2[0] - rv2[0]) + p[0] * (vv2[2] + rv2[2]),
                                p[2] * (Real(1.) - vsq2[0] - vsq2[1]) + p[0] * (vv2[1] - rv2[1]) + p[1] * (vv2[0] + rv2[0]));
     }
@@ -77,24 +77,24 @@ public:
     Quaternion inverse() const { return Quaternion(-r, v); }
     
     Real getAngle() const { return Real(2.) * atan2(v.length(), r); }
-    Vector<Real, 3> getAxis() const { return v.normalize(); }
+    PVector<Real, 3> getAxis() const { return v.normalize(); }
     
     const Real &operator[](int i) const { return (i == 0) ? r : v[i - 1]; }
-    void set(const Real &inR, const Vector<Real, 3> &inV) {
+    void set(const Real &inR, const PVector<Real, 3> &inV) {
         Real ratio = Real(1.) / sqrt(inR * inR + inV.lengthsq()); 
         r = inR * ratio; v = inV * ratio; //normalize
     }
     
 private:
-    Quaternion(const Real &inR, const Vector<Real, 3> &inV) : r(inR), v(inV) {}
+    Quaternion(const Real &inR, const PVector<Real, 3> &inV) : r(inR), v(inV) {}
     
     Real r;
-    Vector<Real, 3> v;
+    PVector<Real, 3> v;
 };
 
 template<class Real = double> class Transform { //T(v) = (rot * v * scale) + trans
 public:
-    typedef Vector<Real, 3> Vec;
+    typedef PVector<Real, 3> Vec;
     
     Transform() : scale(1.) {}
     explicit Transform(const Real &inScale) : scale(inScale) {}
@@ -122,7 +122,7 @@ private:
 
 template<class Real = double> class Matrix3 {
 public:
-    typedef Vector<Real, 3> Vec;
+    typedef PVector<Real, 3> Vec;
     typedef Matrix3<Real> Self;
     
     Matrix3(const Real &diag = Real()) { m[0] = m[4] = m[8] = diag; m[1] = m[2] = m[3] = m[5] = m[6] = m[7] = Real(); }

--- a/libs/pinocchio/vector.h
+++ b/libs/pinocchio/vector.h
@@ -33,27 +33,27 @@ template <int Dim> class VecOp;
 }
 
 template <class Real, int Dim>
-class Vector
+class PVector
 {
 public:
-    typedef Vector<Real, Dim> Self;
+    typedef PVector<Real, Dim> Self;
     typedef _VectorPrivate::VecOp<Dim> VO;
 
-    Vector() { VO::assign(Real(), *this); }
-    Vector(const Self &other) { VO::assign(other, *this); }
-    explicit Vector(const Real &m) { VO::assign(m, *this); }
-    Vector(const Real &m1, const Real &m2) { m[0] = m1; m[1] = m2; checkDim<2>(VO()); }
-    Vector(const Real &m1, const Real &m2, const Real &m3) { m[0] = m1; m[1] = m2; m[2] = m3; checkDim<3>(VO()); }
-    template<class R> Vector(const Vector<R, Dim> &other) { VO::assign(other, *this); }
+    PVector() { VO::assign(Real(), *this); }
+    PVector(const Self &other) { VO::assign(other, *this); }
+    explicit PVector(const Real &m) { VO::assign(m, *this); }
+    PVector(const Real &m1, const Real &m2) { m[0] = m1; m[1] = m2; checkDim<2>(VO()); }
+    PVector(const Real &m1, const Real &m2, const Real &m3) { m[0] = m1; m[1] = m2; m[2] = m3; checkDim<3>(VO()); }
+    template<class R> PVector(const PVector<R, Dim> &other) { VO::assign(other, *this); }
 
     Real &operator[](int n) { return m[n]; }
     const Real &operator[](int n) const { return m[n]; }
 
 //basic recursive functions
-    template<class F> Vector<typename F::result_type, Dim> apply(const F &func) const
+    template<class F> PVector<typename F::result_type, Dim> apply(const F &func) const
     { return VO::apply(func, *this); }
 
-    template<class F> Vector<typename F::result_type, Dim> apply(const F &func, const Self &other) const
+    template<class F> PVector<typename F::result_type, Dim> apply(const F &func, const Self &other) const
     { return VO::apply(func, *this, other); }
 
     template<class Op, class Accum>
@@ -88,35 +88,35 @@ public:
     int size() const { return Dim; }
     
 private:
-    template<class R, int D> friend class Vector;
+    template<class R, int D> friend class PVector;
     template<int WantedDim> void checkDim(const _VectorPrivate::VecOp<WantedDim> &) const {}
 
     Real m[Dim];
 };
 
 template <class Real>
-class Vector<Real, -1>
+class PVector<Real, -1>
 {
 public:
-    typedef Vector<Real, -1> Self;
+    typedef PVector<Real, -1> Self;
 
-    Vector() { }
-    Vector(const Self &other) : m(other.m) { }
-    Vector(const vector<Real> &inM) : m(inM) { }
-    explicit Vector(const Real &inM) { m.push_back(inM); }
+    PVector() { }
+    PVector(const Self &other) : m(other.m) { }
+    PVector(const vector<Real> &inM) : m(inM) { }
+    explicit PVector(const Real &inM) { m.push_back(inM); }
 
     Real &operator[](int n) { if((int)m.size() <= n) m.resize(n + 1); return m[n]; }
-    const Real &operator[](int n) const { if((int)m.size() <= n) const_cast<Vector<Real, -1> *>(this)->m.resize(n + 1); return m[n]; }
+    const Real &operator[](int n) const { if((int)m.size() <= n) const_cast<PVector<Real, -1> *>(this)->m.resize(n + 1); return m[n]; }
 
 //basic recursive functions
-    template<class F> Vector<typename F::result_type, -1> apply(const F &func) const
+    template<class F> PVector<typename F::result_type, -1> apply(const F &func) const
     { 
         vector<typename F::result_type> out(m.size());
         transform(m.begin(), m.end(), out.begin(), func);
-        return Vector<typename F::result_type, -1>(out);
+        return PVector<typename F::result_type, -1>(out);
     }
 
-    template<class F> Vector<typename F::result_type, -1> apply(const F &func, const Self &other) const
+    template<class F> PVector<typename F::result_type, -1> apply(const F &func, const Self &other) const
     {
         vector<typename F::result_type> out(max(m.size(), other.m.size()));
         if(m.size() == other.m.size())
@@ -128,7 +128,7 @@ public:
             transform(m.begin(), m.begin() + (other.m.end() - other.m.begin()), other.m.begin(), out.begin(), func);
             for(int i = other.m.size(); i < (int)m.size(); ++i) out[i] = func(m[i], Real());
         }
-        return Vector<typename F::result_type, -1>(out);
+        return PVector<typename F::result_type, -1>(out);
     }
 
     template<class Op, class Accum>
@@ -191,25 +191,25 @@ private:
 
 
 template <class Real, int Dim>
-Vector<Real, Dim> operator*(const Real &scalar, const Vector<Real, Dim> &vec)
+PVector<Real, Dim> operator*(const Real &scalar, const PVector<Real, Dim> &vec)
 {
     return vec * scalar; //multiplication commutes around here
 }
 
 //cross product
 template <class Real>
-Vector<Real, 3> operator%(const Vector<Real, 3> &v1, const Vector<Real, 3> &v2)
+PVector<Real, 3> operator%(const PVector<Real, 3> &v1, const PVector<Real, 3> &v2)
 {
-    return Vector<Real, 3>(v1[1] * v2[2] - v1[2] * v2[1],
+    return PVector<Real, 3>(v1[1] * v2[2] - v1[2] * v2[1],
                    v1[2] * v2[0] - v1[0] * v2[2],
                    v1[0] * v2[1] - v1[1] * v2[0]);
 }
 
-typedef Vector<double, 3> Vector3;
-typedef Vector<double, 2> Vector2;
+typedef PVector<double, 3> Vector3;
+typedef PVector<double, 2> Vector2;
 
 template <class charT, class traits, class Real, int Dim>
-basic_ostream<charT,traits>& operator<<(basic_ostream<charT,traits>& os, const Vector<Real, Dim> &v)
+basic_ostream<charT,traits>& operator<<(basic_ostream<charT,traits>& os, const PVector<Real, Dim> &v)
 {
     os << "[";
     int ms = Dim;
@@ -225,16 +225,16 @@ basic_ostream<charT,traits>& operator<<(basic_ostream<charT,traits>& os, const V
 }
 
 namespace _VectorPrivate {
-#define VRD Vector<R, D>
-#define VRD1 Vector<R1, D>
+#define VRD PVector<R, D>
+#define VRD1 PVector<R1, D>
 template <int Dim>
 class VecOp
 {
-private:
+public:
     static const int last = Dim - 1;
     typedef VecOp<Dim - 1> Next;
     template<int D> friend class VecOp;
-    template<class R, int D> friend class Vector;
+    template<class R, int D> friend class PVector;
 
     template<class R, class R1, int D>
     static void assign(const VRD1 &from, VRD &to) { to[last] = from[last]; Next::assign(from, to); }
@@ -243,12 +243,12 @@ private:
     static void assign(const R1 &from, VRD &to) { to[last] = from; Next::assign(from, to); }
 
     template<class R, int D, class F>
-    static Vector<typename F::result_type, D> apply(const F &func, const VRD &v)
-    { Vector<typename F::result_type, D> out; _apply(func, v, out); return out; }
+    static PVector<typename F::result_type, D> apply(const F &func, const VRD &v)
+    { PVector<typename F::result_type, D> out; _apply(func, v, out); return out; }
 
     template<class R, int D, class F>
-    static Vector<typename F::result_type, D> apply(const F &func, const VRD &v, const VRD &other)
-    { Vector<typename F::result_type, D> out; _apply(func, v, other, out); return out; }
+    static PVector<typename F::result_type, D> apply(const F &func, const VRD &v, const VRD &other)
+    { PVector<typename F::result_type, D> out; _apply(func, v, other, out); return out; }
 
     template<class R, int D, class Op, class Accum>
     static typename Accum::result_type accumulate(const Op &op, const Accum &accum, const VRD &v)
@@ -259,18 +259,18 @@ private:
     { return accum(op(v[last], other[last]), Next::accumulate(op, accum, v, other)); }
 
     template<class R, int D, class F>
-    static void _apply(const F &func, const VRD &v, Vector<typename F::result_type, D> &out)
+    static void _apply(const F &func, const VRD &v, PVector<typename F::result_type, D> &out)
     { out[last] = func(v[last]); Next::_apply(func, v, out); }
 
     template<class R, int D, class F>
-    static void _apply(const F &func, const VRD &v, const VRD &other, Vector<typename F::result_type, D> &out)
+    static void _apply(const F &func, const VRD &v, const VRD &other, PVector<typename F::result_type, D> &out)
     { out[last] = func(v[last], other[last]); Next::_apply(func, v, other, out); }
 };
 
 template <>
 class VecOp<1>
 {
-private:
+public:
     template<int D> friend class VecOp;
 
     template<class R, class R1, int D> static void assign(const VRD1 &from, VRD &to) { to[0] = from[0]; }
@@ -278,12 +278,12 @@ private:
     template<class R, class R1, int D> static void assign(const R1 &from, VRD &to) { to[0] = from; }
     
     template<class R, int D, class F>
-    static Vector<typename F::result_type, D> apply(const F &func, const VRD &v)
-    { Vector<typename F::result_type, D> out; _apply(func, v, out); return out; }
+    static PVector<typename F::result_type, D> apply(const F &func, const VRD &v)
+    { PVector<typename F::result_type, D> out; _apply(func, v, out); return out; }
 
     template<class R, int D, class F>
-    static Vector<typename F::result_type, D> apply(const F &func, const VRD &v, const VRD &other)
-    { Vector<typename F::result_type, D> out; _apply(func, v, other, out); return out; }
+    static PVector<typename F::result_type, D> apply(const F &func, const VRD &v, const VRD &other)
+    { PVector<typename F::result_type, D> out; _apply(func, v, other, out); return out; }
     
     template<class R, int D, class Op, class Accum>
     static typename Accum::result_type accumulate(const Op &op, const Accum &, const VRD &v)
@@ -294,11 +294,11 @@ private:
     { return op(v[0], other[0]); }
 
     template<class R, int D, class F>
-    static void _apply(const F &func, const VRD &v, Vector<typename F::result_type, D> &out)
+    static void _apply(const F &func, const VRD &v, PVector<typename F::result_type, D> &out)
     { out[0] = func(v[0]); }
 
     template<class R, int D, class F>
-    static void _apply(const F &func, const VRD &v, const VRD &other, Vector<typename F::result_type, D> &out)
+    static void _apply(const F &func, const VRD &v, const VRD &other, PVector<typename F::result_type, D> &out)
     { out[0] = func(v[0], other[0]); }
 };
 } //namespace _VectorPrivate

--- a/libs/pinocchio/vecutils.h
+++ b/libs/pinocchio/vecutils.h
@@ -22,40 +22,40 @@
 #include "vector.h"
 
 template<class Real>
-void getBasis(const Vector<Real, 3> &n, Vector<Real, 3> &v1, Vector<Real, 3> &v2)
+void getBasis(const PVector<Real, 3> &n, PVector<Real, 3> &v1, PVector<Real, 3> &v2)
 {
     if(n.lengthsq() < Real(1e-16)) {
-        v1 = Vector<Real, 3>(1., 0., 0.);
-        v2 = Vector<Real, 3>(0., 1., 0.);
+        v1 = PVector<Real, 3>(1., 0., 0.);
+        v2 = PVector<Real, 3>(0., 1., 0.);
         return;
     }
     if(fabs(n[0]) <= fabs(n[1]) && fabs(n[0]) <= fabs(n[2]))
-        v2 = Vector<Real, 3>(1., 0., 0.);
+        v2 = PVector<Real, 3>(1., 0., 0.);
     else if(fabs(n[1]) <= fabs(n[2]))
-        v2 = Vector<Real, 3>(0., 1., 0.);
+        v2 = PVector<Real, 3>(0., 1., 0.);
     else
-        v2 = Vector<Real, 3>(0., 0., 1.);
+        v2 = PVector<Real, 3>(0., 0., 1.);
     
     v1 = (n % v2).normalize(); //first basis vector
     v2 = (n % v1).normalize(); //second basis vector
 }
 
 template<class Real, int Dim>
-Real distsqToLine(const Vector<Real, Dim> &v, const Vector<Real, Dim> &l, const Vector<Real, Dim> &dir)
+Real distsqToLine(const PVector<Real, Dim> &v, const PVector<Real, Dim> &l, const PVector<Real, Dim> &dir)
 {
   return max(Real(), (v - l).lengthsq() - SQR((v - l) * dir) / dir.lengthsq());
 }
 
 template<class Real, int Dim>
-Vector<Real, Dim> projToLine(const Vector<Real, Dim> &v, const Vector<Real, Dim> &l, const Vector<Real, Dim> &dir)
+PVector<Real, Dim> projToLine(const PVector<Real, Dim> &v, const PVector<Real, Dim> &l, const PVector<Real, Dim> &dir)
 {
   return l + (((v - l) * dir) / dir.lengthsq()) * dir;
 }
 
 template<class Real, int Dim>
-Real distsqToSeg(const Vector<Real, Dim> &v, const Vector<Real, Dim> &p1, const Vector<Real, Dim> &p2)
+Real distsqToSeg(const PVector<Real, Dim> &v, const PVector<Real, Dim> &p1, const PVector<Real, Dim> &p2)
 {
-  typedef Vector<Real, Dim> Vec;
+  typedef PVector<Real, Dim> Vec;
   
   Vec dir = p2 - p1;
   Vec difp2 = p2 - v;
@@ -73,9 +73,9 @@ Real distsqToSeg(const Vector<Real, Dim> &v, const Vector<Real, Dim> &p1, const 
 }
 
 template<class Real, int Dim>
-Vector<Real, Dim> projToSeg(const Vector<Real, Dim> &v, const Vector<Real, Dim> &p1, const Vector<Real, Dim> &p2)
+PVector<Real, Dim> projToSeg(const PVector<Real, Dim> &v, const PVector<Real, Dim> &p1, const PVector<Real, Dim> &p2)
 {
-  typedef Vector<Real, Dim> Vec;
+  typedef PVector<Real, Dim> Vec;
 
   Vec dir = p2 - p1;
 
@@ -111,9 +111,9 @@ Real getCircleIntersectionArea(const Real &d, const Real &r1, const Real &r2)
 }
 
 template<class Real>
-Vector<Real, 3> projToTri(const Vector<Real, 3> &from, const Vector<Real, 3> &p1, const Vector<Real, 3> &p2, const Vector<Real, 3> &p3)
+PVector<Real, 3> projToTri(const PVector<Real, 3> &from, const PVector<Real, 3> &p1, const PVector<Real, 3> &p2, const PVector<Real, 3> &p3)
 {
-    typedef Vector<Real, 3> Vec;
+    typedef PVector<Real, 3> Vec;
     Real tolsq(1e-16);
     
     Vec p2p1 = (p2 - p1);

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -7,11 +7,11 @@ Vectorn<Real> getFeet(const vector<Transform<Real> > &transforms, const vector<V
 {
     int i;
     Vectorn<Real> out;
-    Vectorn<Vector<Real, 3> > results(joints.size());
+    Vectorn<PVector<Real, 3> > results(joints.size());
 
-    results[0] = transforms[0] * Vector<Real, 3>(joints[0]);
+    results[0] = transforms[0] * PVector<Real, 3>(joints[0]);
     for(i = 1; i < (int)joints.size(); ++i) {
-        results[i] = results[prev[i]] + transforms[i - 1].getRot() * Vector<Real, 3>(joints[i] - joints[prev[i]]);
+        results[i] = results[prev[i]] + transforms[i - 1].getRot() * PVector<Real, 3>(joints[i] - joints[prev[i]]);
     }
 
     out.push_back(results[7][0]);
@@ -84,7 +84,7 @@ Matrixn<double> MotionFilter::getJac(const vector<Transform<> > &transforms) con
     int i, j;
 
     Vectorn<double> transVec = toVector(transforms);
-    Vector<D, 3> trans0;
+    PVector<D, 3> trans0;
     for(i = 0; i < 3; ++i)
         trans0[i] = D(transVec[i], i);
 
@@ -92,7 +92,7 @@ Matrixn<double> MotionFilter::getJac(const vector<Transform<> > &transforms) con
         int curIdx = 3 + i * 4;
 
         Quaternion<D> rot;
-        rot.set(D(transVec[curIdx], curIdx), Vector<D, 3>(D(transVec[curIdx + 1], curIdx + 1),
+        rot.set(D(transVec[curIdx], curIdx), PVector<D, 3>(D(transVec[curIdx + 1], curIdx + 1),
                                                           D(transVec[curIdx + 2], curIdx + 2),
                                                           D(transVec[curIdx + 3], curIdx + 3)));
         

--- a/src/ofxAutoRiggingModel.cpp
+++ b/src/ofxAutoRiggingModel.cpp
@@ -84,7 +84,7 @@ void AutoRigging::ofxAutoRiggingModel::load(string _fileMesh, string _fileMotion
 		//output attachment
 		std::ofstream astrm(ofToDataPath("/attachment.out",true));
 		for(int i = 0; i < (int)m.vertices.size(); ++i) {
-			Vector<double, -1> v = o.attachment->getWeights(i);
+			PVector<double, -1> v = o.attachment->getWeights(i);
 			for(int j = 0; j < v.size(); ++j) {
 			    double d = floor(0.5 + v[j] * 10000.) / 10000.;
 			    astrm << d << " ";


### PR DESCRIPTION
Hey Kashim,

Here's the pull to rename Rect and Vector classes. It helped me building your addon on OSX.
It's tested with the example project and runs great.

Thank you!